### PR TITLE
refactor/dependency-injection

### DIFF
--- a/src/Form/JsonLDMarkupSettingsForm.php
+++ b/src/Form/JsonLDMarkupSettingsForm.php
@@ -1,11 +1,12 @@
 <?php
 
-// phpcs:disable -- DrupalPractice.Objects.GlobalDrupal.GlobalDrupal
-
 namespace Drupal\jsonld_markup\Form;
 
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Config form for the module.
@@ -15,6 +16,36 @@ use Drupal\Core\Form\FormStateInterface;
 class JsonLDMarkupSettingsForm extends FormBase {
 
   const JSONLD_MARKUP_SETTINGS_PAGE = 'jsonld_markup_settings_page:values';
+
+  /**
+   * The state service.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected StateInterface $state;
+
+  /**
+   * Constructs a JsonLDMarkupSettingsForm object.
+   *
+   * @param \Drupal\Core\State\StateInterface $state
+   *   The state service.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
+   */
+  public function __construct(StateInterface $state, MessengerInterface $messenger) {
+    $this->state = $state;
+    $this->messenger = $messenger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('state'),
+      $container->get('messenger')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -27,7 +58,7 @@ class JsonLDMarkupSettingsForm extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $values = \Drupal::state()->get(self::JSONLD_MARKUP_SETTINGS_PAGE);
+    $values = $this->state->get(self::JSONLD_MARKUP_SETTINGS_PAGE);
     $form = [];
 
     $form['schema_field'] = [
@@ -62,9 +93,8 @@ class JsonLDMarkupSettingsForm extends FormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $submitted_values = $form_state->cleanValues()->getValues();
 
-    \Drupal::state()->set(self::JSONLD_MARKUP_SETTINGS_PAGE, $submitted_values);
-    $messenger = \Drupal::service('messenger');
-    $messenger->addMessage($this->t("Configuration Saved"));
+    $this->state->set(self::JSONLD_MARKUP_SETTINGS_PAGE, $submitted_values);
+    $this->messenger->addMessage($this->t("Configuration Saved"));
   }
 
 }


### PR DESCRIPTION
# Description
This PR refactors the codebase to use Dependency Injection to avoid using direct `\Drupal` service calls, which is highly recommended by Drupal.
Reference: [Services and dependency injection in Drupal](https://www.drupal.org/docs/drupal-apis/services-and-dependency-injection/services-and-dependency-injection-in-drupal#:~:text=service%20setter%20methods.-,Using%20dependency%20injection,using%20services%20in%20Drupal%208%2B%20and%20should%20be%20used%20whenever%20possible.,-Rather%20than%20calling)